### PR TITLE
feature/AB#28279 Refactor organization info and backend integration

### DIFF
--- a/applications/Grants.ApplicantPortal/src/Grants.ApplicantPortal.Backend/src/Grants.ApplicantPortal.API.Infrastructure/Plugins/Demo/DemoProfilePlugin.cs
+++ b/applications/Grants.ApplicantPortal/src/Grants.ApplicantPortal.Backend/src/Grants.ApplicantPortal.API.Infrastructure/Plugins/Demo/DemoProfilePlugin.cs
@@ -65,12 +65,12 @@ public class DemoProfilePlugin(ILogger<DemoProfilePlugin> logger) : IProfilePlug
 
         return (metadata.Provider?.ToUpper(), metadata.Key?.ToUpper()) switch
         {
-            ("PROGRAM1", "SUBMISSIONS") => GenerateProgram1Submissions(baseData),
-            ("PROGRAM1", "ORGINFO") => GenerateProgram1OrgInfo(baseData),
-            ("PROGRAM1", "PAYMENTS") => GenerateProgram1Payments(baseData),
-            ("PROGRAM2", "SUBMISSIONS") => GenerateProgram2Submissions(baseData),
-            ("PROGRAM2", "ORGINFO") => GenerateProgram2OrgInfo(baseData),
-            ("PROGRAM2", "PAYMENTS") => GenerateProgram2Payments(baseData),
+            ("DEMO", "SUBMISSIONS") => GenerateProgram1Submissions(baseData),
+            ("DEMO", "ORGINFO") => GenerateProgram1OrgInfo(baseData),
+            ("DEMO", "PAYMENTS") => GenerateProgram1Payments(baseData),
+            ("UNITY", "SUBMISSIONS") => GenerateProgram2Submissions(baseData),
+            ("UNITY", "ORGINFO") => GenerateProgram2OrgInfo(baseData),
+            ("UNITY", "PAYMENTS") => GenerateProgram2Payments(baseData),
             _ => GenerateDefaultData(baseData)
         };
     }
@@ -139,11 +139,18 @@ public class DemoProfilePlugin(ILogger<DemoProfilePlugin> logger) : IProfilePlug
             {
                 OrganizationInfo = new
                 {
+                    OrgName = "Cowichan Exhibition",
+                    OrgNumber = "S0003748",
+                    OrgStatus =  "Active", 
+                    OrganizationType = "Society",
+                    NonRegOrgName = "Shrine Org",
+                    OrgSize = "50",
+                    FiscalMonth = "Aug",
+                    FiscalDay = 1,
                     OrganizationId = "ORG-DEMO-001",
                     LegalName = "Demo Community Health Foundation",
                     DoingBusinessAs = "DCHF",
                     EIN = "12-3456789",
-                    OrganizationType = "501(c)(3) Nonprofit",
                     Founded = 2010,
                     Address = new
                     {

--- a/applications/Grants.ApplicantPortal/src/Grants.ApplicantPortal.Frontend/src/app/core/services/applicant.service.ts
+++ b/applications/Grants.ApplicantPortal/src/Grants.ApplicantPortal.Frontend/src/app/core/services/applicant.service.ts
@@ -3,11 +3,10 @@ import { HttpClient } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
 import {
   ApplicantInfo,
-  OrganizationInfo,
   ContactInfo,
   AddressInfo,
-  Submission,
-} from '../../shared/models/applicant.model';
+} from '../../shared/models/applicant.interface';
+import { OrganizationData } from '../../shared/models/applicant-info.interface';
 
 @Injectable({
   providedIn: 'root',
@@ -22,19 +21,6 @@ export class ApplicantService {
     return of({
       id: '368GB783',
       organization: 'Your Amazing Organization Inc.',
-    });
-  }
-
-  getOrganizationInfo(): Observable<OrganizationInfo> {
-    return of({
-      orgRegisteredNumber: '234523523423423',
-      orgStatus: 'Active',
-      orgType: 'Sole Proprietorship',
-      orgName: 'Your Amazing Organization',
-      orgSize: '50',
-      nonRegOrgName: 'N/A',
-      fiscalYearEndMonth: 'December',
-      fiscalYearEndDay: '31',
     });
   }
 
@@ -80,7 +66,7 @@ export class ApplicantService {
     ]);
   }
 
-  saveOrganizationInfo(orgInfo: OrganizationInfo): Observable<any> {
+  saveOrganizationInfo(orgInfo: OrganizationData): Observable<any> {
     // Replace with actual API call
     return of({ success: true });
   }

--- a/applications/Grants.ApplicantPortal/src/Grants.ApplicantPortal.Frontend/src/app/core/services/organization.service.ts
+++ b/applications/Grants.ApplicantPortal/src/Grants.ApplicantPortal.Frontend/src/app/core/services/organization.service.ts
@@ -1,0 +1,94 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
+import {
+  ProfileId,
+  PluginId,
+  Provider,
+  Key,
+} from '../../shared/models/organization.enums';
+import {
+  BackendResponse,
+  HydrateRequest,
+  OrganizationResponse,
+} from '../../shared/models/applicant-info.interface';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OrganizationService {
+  private readonly baseUrl = 'https://localhost:7000';
+
+  // Default parameters as constants
+  private readonly defaults = {
+    profileId: ProfileId.DEFAULT,
+    pluginId: PluginId.DEMO,
+    provider: Provider.DEMO,
+    key: Key.ORGINFO,
+  };
+
+  constructor(private readonly http: HttpClient) {}
+
+  /**
+   * Hydrates organization information
+   */
+  private hydrateOrganizationInfo(data?: any): Observable<BackendResponse> {
+    const { profileId, pluginId, provider, key } = this.defaults;
+    const url = `${this.baseUrl}/Profiles/${profileId}/${pluginId}/${provider}/${key}/hydrate`;
+    const body: HydrateRequest = { data };
+    return this.http.post<BackendResponse>(url, body);
+  }
+
+  /**
+   * Gets organization information from backend
+   */
+  private getOrganizationInfo(): Observable<BackendResponse> {
+    const { profileId, pluginId, provider, key } = this.defaults;
+    const url = `${this.baseUrl}/Profiles/${profileId}/${pluginId}/${provider}/${key}`;
+    return this.http.get<BackendResponse>(url);
+  }
+
+  /**
+   * Parses backend response and extracts organization data
+   */
+  private parseResponse(response: BackendResponse): OrganizationResponse {
+    try {
+      const parsedData = JSON.parse(response.jsonData);
+
+      return {
+        metadata: {
+          profileId: response.profileId,
+          pluginId: response.pluginId,
+          provider: response.provider,
+          key: response.key,
+          populatedAt: response.populatedAt,
+        },
+        organizationData: parsedData.data.organizationInfo,
+      };
+    } catch (error) {
+      console.error('Error parsing organization data:', error);
+      throw new Error('Failed to parse organization data');
+    }
+  }
+
+  /**
+   * Main method: Hydrates and returns formatted organization information
+   * This is the only public method you need to call
+   */
+  hydrateAndGetOrganizationInfo(data?: any): Observable<OrganizationResponse> {
+    return this.hydrateOrganizationInfo(data).pipe(
+      switchMap(() => this.getOrganizationInfo()),
+      map((response) => this.parseResponse(response))
+    );
+  }
+
+  /**
+   * Gets already hydrated organization information (without hydrating first)
+   */
+  getFormattedOrganizationInfo(): Observable<OrganizationResponse> {
+    return this.getOrganizationInfo().pipe(
+      map((response) => this.parseResponse(response))
+    );
+  }
+}

--- a/applications/Grants.ApplicantPortal/src/Grants.ApplicantPortal.Frontend/src/app/features/applicant-info/components/applicant-info.component.html
+++ b/applications/Grants.ApplicantPortal/src/Grants.ApplicantPortal.Frontend/src/app/features/applicant-info/components/applicant-info.component.html
@@ -57,17 +57,15 @@
                       class="search-result-item"
                       (click)="onSearchResultSelect(result)"
                     >
-                      <div class="result-name">{{ result.name }}</div>
+                      <div class="result-name">{{ result.orgName }}</div>
                       <div class="result-details">
-                        <span class="reg-number">{{
-                          result.registeredNumber
-                        }}</span>
+                        <span class="reg-number">{{ result.orgNumber }}</span>
                         <span
                           class="status"
-                          [class.active]="result.status === 'Active'"
-                          >{{ result.status }}</span
+                          [class.active]="result.orgStatus === 'Active'"
+                          >{{ result.orgStatus }}</span
                         >
-                        <span class="type">{{ result.type }}</span>
+                        <span class="type">{{ result.organizationType }}</span>
                       </div>
                     </div>
                     }
@@ -92,7 +90,7 @@
                 <input
                   id="orgName"
                   type="text"
-                  [value]="organizationInfo?.orgName"
+                  [value]="organizationData?.orgName"
                   disabled
                   class="form-control"
                 />
@@ -104,7 +102,7 @@
                 <input
                   id="regNumber"
                   type="text"
-                  [value]="organizationInfo?.orgRegisteredNumber"
+                  [value]="organizationData?.orgNumber"
                   disabled
                   class="form-control"
                 />
@@ -118,7 +116,7 @@
                 <label for="orgStatus">Organization Book Status</label>
                 <input
                   id="orgStatus"
-                  [value]="organizationInfo?.orgStatus"
+                  [value]="organizationData?.orgStatus"
                   disabled
                   class="form-control"
                 />
@@ -131,8 +129,8 @@
                   id="orgType"
                   type="text"
                   [value]="
-                    organizationInfo?.orgType
-                      ? organizationInfo?.orgType
+                    organizationData?.organizationType
+                      ? organizationData?.organizationType
                       : 'N/A'
                   "
                   disabled
@@ -151,7 +149,7 @@
                 <input
                   id="nonRegOrgName"
                   type="text"
-                  [value]="organizationInfo?.nonRegOrgName"
+                  [value]="organizationData?.nonRegOrgName"
                   class="form-control"
                 />
               </div>
@@ -162,7 +160,7 @@
                 <input
                   id="orgSize"
                   type="text"
-                  [value]="organizationInfo?.orgSize"
+                  [value]="organizationData?.orgSize"
                   class="form-control"
                 />
               </div>
@@ -172,10 +170,10 @@
           <div class="row">
             <div class="col-md-6">
               <div class="field">
-                <label for="fiscalYearEndMonth">Fiscal Year End Month</label>
+                <label for="fiscalMonth">Fiscal Year End Month</label>
                 <select
                   class="form-select"
-                  id="fiscalYearEndMonth"
+                  id="fiscalMonth"
                   [(ngModel)]="selectedFiscalMonth"
                   (change)="onFiscalMonthChange($event)"
                 >
@@ -197,10 +195,10 @@
             </div>
             <div class="col-md-6">
               <div class="field">
-                <label for="fiscalYearEndDay">Fiscal Year End Day</label>
+                <label for="fiscalDay">Fiscal Year End Day</label>
                 <select
                   class="form-select"
-                  id="fiscalYearEndDay"
+                  id="fiscalDay"
                   [(ngModel)]="selectedFiscalDay"
                 >
                   <option selected>Select Day</option>

--- a/applications/Grants.ApplicantPortal/src/Grants.ApplicantPortal.Frontend/src/app/features/applicant-info/components/submissions.component.ts
+++ b/applications/Grants.ApplicantPortal/src/Grants.ApplicantPortal.Frontend/src/app/features/applicant-info/components/submissions.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Submission } from '../../../shared/models/applicant.model';
+import { Submission } from '../../../shared/models/applicant.interface';
 
 @Component({
   selector: 'app-submissions',

--- a/applications/Grants.ApplicantPortal/src/Grants.ApplicantPortal.Frontend/src/app/layout/components/header.component.ts
+++ b/applications/Grants.ApplicantPortal/src/Grants.ApplicantPortal.Frontend/src/app/layout/components/header.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router, NavigationEnd } from '@angular/router';
 import { UserDropdownComponent } from '../../shared/components/user-dropdown/user-dropdown.component';
-import { ApplicantInfo } from '../../shared/models/applicant.model';
+import { ApplicantInfo } from '../../shared/models/applicant.interface';
 import { filter } from 'rxjs/operators';
 import { Subscription } from 'rxjs';
 

--- a/applications/Grants.ApplicantPortal/src/Grants.ApplicantPortal.Frontend/src/app/layout/components/layout.component.ts
+++ b/applications/Grants.ApplicantPortal/src/Grants.ApplicantPortal.Frontend/src/app/layout/components/layout.component.ts
@@ -4,7 +4,7 @@ import { RouterOutlet } from '@angular/router';
 import { HeaderComponent } from './header.component';
 import { SidebarComponent } from './sidebar.component';
 import { ApplicantService } from '../../core/services/applicant.service';
-import { ApplicantInfo } from '../../shared/models/applicant.model';
+import { ApplicantInfo } from '../../shared/models/applicant.interface';
 import { UserDropdownComponent } from '../../shared/components/user-dropdown/user-dropdown.component';
 
 @Component({

--- a/applications/Grants.ApplicantPortal/src/Grants.ApplicantPortal.Frontend/src/app/shared/models/applicant-info.interface.ts
+++ b/applications/Grants.ApplicantPortal/src/Grants.ApplicantPortal.Frontend/src/app/shared/models/applicant-info.interface.ts
@@ -1,0 +1,86 @@
+export interface HydrateRequest {
+  data?: any;
+}
+
+export interface BackendResponse {
+  profileId: string;
+  pluginId: string;
+  provider: string;
+  key: string;
+  jsonData: string;
+  populatedAt: string;
+}
+
+export interface Address {
+  street: string;
+  city: string;
+  state: string;
+  zipCode: string;
+  country: string;
+}
+
+export interface Contact {
+  name: string;
+  title: string;
+  email: string;
+  phone: string;
+}
+
+export interface ContactInfo {
+  primaryContact: Contact;
+  grantsContact: Contact;
+}
+
+export interface Certification {
+  type: string;
+  validUntil: string;
+}
+
+export interface Program1Specific {
+  eligibilityStatus: string;
+  lastAuditDate: string;
+  complianceScore: number;
+  specialDesignations: string[];
+}
+
+export interface OrganizationData {
+  orgName: string;
+  orgNumber: string;
+  orgStatus: string;
+  organizationType: string;
+  nonRegOrgName: string;
+  orgSize: string;
+  fiscalMonth: string;
+  fiscalDay: number;
+  organizationId: string;
+  legalName: string;
+  doingBusinessAs: string;
+  ein: string;
+  founded: number;
+  address: Address;
+  contactInfo: ContactInfo;
+  mission: string;
+  servicesAreas: string[];
+  certifications: Certification[];
+  program1Specific: Program1Specific;
+}
+
+// Single response interface for parsed data
+export interface OrganizationResponse {
+  metadata: {
+    profileId: string;
+    pluginId: string;
+    provider: string;
+    key: string;
+    populatedAt: string;
+  };
+  organizationData: OrganizationData;
+}
+
+export interface OrgSearchResult {
+  id: string;
+  orgName: string;
+  orgNumber: string;
+  orgStatus: string;
+  organizationType: string;
+}

--- a/applications/Grants.ApplicantPortal/src/Grants.ApplicantPortal.Frontend/src/app/shared/models/applicant.interface.ts
+++ b/applications/Grants.ApplicantPortal/src/Grants.ApplicantPortal.Frontend/src/app/shared/models/applicant.interface.ts
@@ -3,17 +3,6 @@ export interface ApplicantInfo {
   organization: string;
 }
 
-export interface OrganizationInfo {
-  orgRegisteredNumber: string;
-  orgStatus: string;
-  orgType: string;
-  orgName: string;
-  orgSize: string;
-  nonRegOrgName: string;
-  fiscalYearEndMonth?: string;
-  fiscalYearEndDay?: string;
-}
-
 export interface ContactInfo {
   firstName: string;
   lastName: string;

--- a/applications/Grants.ApplicantPortal/src/Grants.ApplicantPortal.Frontend/src/app/shared/models/organization.enums.ts
+++ b/applications/Grants.ApplicantPortal/src/Grants.ApplicantPortal.Frontend/src/app/shared/models/organization.enums.ts
@@ -1,0 +1,15 @@
+export enum ProfileId {
+  DEFAULT = '01985d4b-946c-7dee-90f1-8e2b947ffa83',
+}
+
+export enum PluginId {
+  DEMO = 'DEMO',
+}
+
+export enum Provider {
+  DEMO = 'DEMO',
+}
+
+export enum Key {
+  ORGINFO = 'ORGINFO',
+}


### PR DESCRIPTION
- Define OrganizationData and related interfaces, moving them to a new applicant-info.interface.ts file.
- Adds a dedicated OrganizationService for backend integration and updates applicant-info.component to use the new service and data model.
- Update organization search, form fields, and related imports throughout the frontend.
- Update Backend demo plugin dummy data
- Define enums to match new organization data structure and naming.